### PR TITLE
Bumped up notifications and support dependencies to Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 		"laravel 6",
 		"laravel 7",
 		"laravel 8",
+		"laravel 9",
 		"mandrill",
 		"mailchimp",
 		"notifications",
@@ -36,8 +37,8 @@
 		"php": ">=7.0.0",
 		"guzzlehttp/guzzle": "^6.5 || ^7.0",
 		"hellochef-me/php-styles": "^1.0",
-		"illuminate/notifications": "^5.0 || ^6.0 || ^7.0 || ^8.0",
-		"illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+		"illuminate/notifications": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+		"illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
 	},
 	"minimum-stability": "stable",
 	"scripts": {


### PR DESCRIPTION
Laravel 9 was released yesterday and this package is not installable under it unless its dependencies on `illuminate/notifications` and `illuminate/support` are bumped to include `^9.0`. No conflicts seem to happen when this is done.